### PR TITLE
Use AWS Secrets for bot local & deployed; no S3 secrets!

### DIFF
--- a/config/default.py
+++ b/config/default.py
@@ -25,6 +25,10 @@ ENHANCEMENTS, OR MODIFICATIONS.
 
 import logging
 
+AWS_SECRETS_REGION = "us-west-2"
+AWS_SECRETS_NAME_AUTHORIZED_USERS = "AUTHORIZED_USERS"
+AWS_SECRETS_NAME_GCP_JSON_CREDENTIALS = "GCP_JSON_CREDENTIALS"
+
 CAS_SERVER = 'https://auth-test.berkeley.edu/cas/'
 CAS_LOGOUT_URL = 'https://auth-test.berkeley.edu/cas/logout'
 

--- a/hartsfield/api/datahub_archive_url_fetch.py
+++ b/hartsfield/api/datahub_archive_url_fetch.py
@@ -31,6 +31,7 @@ from google.cloud import storage
 from google.oauth2 import service_account
 from hartsfield.api.auth_helper import authorzied_user_required
 from hartsfield.lib.http import tolerant_jsonify
+import hartsfield.api.read_aws_secret
 
 PUBLIC_CONFIGS = [
     'DEV_AUTH_ENABLED',
@@ -38,9 +39,11 @@ PUBLIC_CONFIGS = [
     'TIMEZONE',
 ]
 
-gcp_json_credentials = app.config['GCP_JSON_CREDENTIALS']
-gcp_json_credentials_dict = json.loads(gcp_json_credentials)
+AWS_SECRETS_NAME_GCP_JSON_CREDENTIALS = app.config['AWS_SECRETS_NAME_GCP_JSON_CREDENTIALS']
 
+
+gcp_json_credentials_from_aws = hartsfield.api.read_aws_secret.read_aws_secret(AWS_SECRETS_NAME_GCP_JSON_CREDENTIALS)
+gcp_json_credentials_dict = json.loads(gcp_json_credentials_from_aws)
 
 @app.route('/api/fetch_url_direct', methods=['POST'])
 @authorzied_user_required

--- a/hartsfield/api/read_aws_secret.py
+++ b/hartsfield/api/read_aws_secret.py
@@ -1,0 +1,59 @@
+"""
+Copyright ©2023. The Regents of the University of California (Regents). All Rights Reserved.
+
+Permission to use, copy, modify, and distribute this software and its documentation
+for educational, research, and not-for-profit purposes, without fee and without a
+signed licensing agreement, is hereby granted, provided that the above copyright
+notice, this paragraph and the following two paragraphs appear in all copies,
+modifications, and distributions.
+
+Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+
+IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+"AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ENHANCEMENTS, OR MODIFICATIONS.
+"""
+import boto3
+import json
+import base64
+from flask import current_app as app
+
+PUBLIC_CONFIGS = [
+    'DEV_AUTH_ENABLED',
+    'HARTSFIELD_ENV',
+    'TIMEZONE',
+]
+
+region_name = app.config['AWS_SECRETS_REGION']
+
+
+def read_aws_secret(aws_secret_name):
+
+    # Develepment context: get & activate credentials as described in "Command line or programmatic access"
+    # in "AWS Landing Zone"
+    session = boto3.session.Session()
+    client = session.client(
+        service_name='secretsmanager',
+        region_name=region_name
+    )
+
+    get_secret_value_response = client.get_secret_value(
+        SecretId=aws_secret_name
+    )
+
+    if 'SecretString' in get_secret_value_response:
+        secret = get_secret_value_response['SecretString']
+    else:
+        secret = base64.b64decode(get_secret_value_response['SecretBinary'])
+
+    # Parse the secret JSON string and return the secret value
+    return json.loads(secret)[aws_secret_name]

--- a/hartsfield/models/user.py
+++ b/hartsfield/models/user.py
@@ -24,11 +24,16 @@ ENHANCEMENTS, OR MODIFICATIONS.
 """
 from flask import current_app as app
 from flask_login import UserMixin
+import hartsfield.api.read_aws_secret
+
+AWS_SECRETS_NAME_AUTHORIZED_USERS = app.config['AWS_SECRETS_NAME_AUTHORIZED_USERS']
+authorized_users_text = hartsfield.api.read_aws_secret.read_aws_secret(AWS_SECRETS_NAME_AUTHORIZED_USERS)
+authorized_users_list = [int(user) for user in authorized_users_text.split(',')]
 
 
 def find_by_uid(user_uid):
     if user_uid:
-        uid = next((uid for uid in app.config['AUTHORIZED_USERS'] if uid == int(user_uid)), None)
+        uid = next((uid for uid in authorized_users_list if uid == int(user_uid)), None)
         return User(uid) if uid else None
     else:
         return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,8 @@ pytest==7.2.1
 pytest-flask==1.2.0
 tox==4.3.5
 
+boto3
+
 google-cloud-storage
 google-auth
 google-auth-httplib2


### PR DESCRIPTION
The idea here is that secrets live in AWS Secrets. To develop locally, one auths to AWS and gets secrets from the cloud via IAM role; in deployment, the app uses role given to the Elastic Beanstalk context. No secrets stored on dev HD's nor written to disk file on EB EC2. :)

(Have yet to test on the EB side, but off we go!!)